### PR TITLE
fix: Missing trailing slash

### DIFF
--- a/IONFilesystemLibTests/IONFILEFileManagerTests.swift
+++ b/IONFilesystemLibTests/IONFILEFileManagerTests.swift
@@ -120,7 +120,7 @@ extension IONFILEFileManagerTests {
 
         // Then
         XCTAssertEqual(fileManager.capturedSearchPathDirectory, .cachesDirectory)
-        XCTAssertEqual(fileURL.appending(path: filePath), returnedURL)
+        XCTAssertEqual(fileURL.appendingPathComponent(filePath, isDirectory: true), returnedURL)
     }
 
     func test_getFileURL_fromDirectorySearchPath_containingMultipleFiles_returnsFirstFileSuccessfully() throws {
@@ -128,7 +128,7 @@ extension IONFILEFileManagerTests {
         let fileURL: URL = try XCTUnwrap(.init(string: "/file/directory"))
         let ignoredFileURL: URL = try XCTUnwrap(.init(string: "another_file/directory"))
         let fileManager = createFileManager(urlsWithinDirectory: [fileURL, ignoredFileURL])
-        let filePath = "/test/directory"
+        let filePath = "/test///directory//"
         let directoryType = IONFILEDirectoryType.cache
 
         // When
@@ -136,7 +136,8 @@ extension IONFILEFileManagerTests {
 
         // Then
         XCTAssertEqual(fileManager.capturedSearchPathDirectory, .cachesDirectory)
-        XCTAssertEqual(fileURL.appending(path: filePath), returnedURL)
+        XCTAssert(!returnedURL.absoluteString.contains("//"))
+        XCTAssertEqual(fileURL.appendingPathComponent("/test/directory", isDirectory: true), returnedURL)
     }
 
     func test_getFileURL_fromDocumentDirectorySearchPath_returnsFileSuccessfully() throws {
@@ -151,7 +152,7 @@ extension IONFILEFileManagerTests {
 
         // Then
         XCTAssertEqual(fileManager.capturedSearchPathDirectory, .documentDirectory)
-        XCTAssertEqual(fileURL.appending(path: filePath), returnedURL)
+        XCTAssertEqual(fileURL.appendingPathComponent(filePath, isDirectory: true), returnedURL)
     }
 
     func test_getFileURL_fromLibraryDirectorySearchPath_returnsFileSuccessfully() throws {
@@ -166,14 +167,14 @@ extension IONFILEFileManagerTests {
 
         // Then
         XCTAssertEqual(fileManager.capturedSearchPathDirectory, .libraryDirectory)
-        XCTAssertEqual(fileURL.appending(path: filePath), returnedURL)
+        XCTAssertEqual(fileURL.appendingPathComponent(filePath, isDirectory: true), returnedURL)
     }
 
     func test_getFileURL_fromNotSyncedLibraryDirectorySearchPath_returnsFileSuccessfully() throws {
         // Given
         let fileURL: URL = try XCTUnwrap(.init(string: "/file/directory"))
         let fileManager = createFileManager(urlsWithinDirectory: [fileURL])
-        let filePath = "/test/directory"
+        let filePath = "/test/directory/"
         let directoryType = IONFILEDirectoryType.notSyncedLibrary
 
         // When
@@ -181,7 +182,8 @@ extension IONFILEFileManagerTests {
 
         // Then
         XCTAssertEqual(fileManager.capturedSearchPathDirectory, .libraryDirectory)
-        XCTAssertEqual(fileURL.appending(path: "NoCloud").appending(path: filePath), returnedURL)
+        XCTAssert(!returnedURL.absoluteString.contains("//"))
+        XCTAssertEqual(fileURL.appending(path: "NoCloud").appendingPathComponent("/test/directory", isDirectory: true), returnedURL)
     }
 
     func test_getFileURL_fromTemporaryDirectorySearchPath_returnsFileSuccessfully() throws {
@@ -197,7 +199,7 @@ extension IONFILEFileManagerTests {
 
         // Then
         XCTAssertEqual(fileManager.temporaryDirectory, parentFolderURL)
-        XCTAssertEqual(parentFolderURL.appending(path: filePath), returnedURL)
+        XCTAssertEqual(parentFolderURL.appendingPathComponent(filePath, isDirectory: true), returnedURL)
     }
 
     func test_getFileURL_fromDirectorySearchPath_containingNoFiles_returnsError() {
@@ -225,7 +227,7 @@ extension IONFILEFileManagerTests {
 
         // Then
         XCTAssertEqual(fileManager.capturedSearchPathDirectory, .cachesDirectory)
-        XCTAssertEqual(fileURL, returnedURL)
+        XCTAssertEqual(fileURL.appendingPathComponent(""), returnedURL)
     }
 
     func test_getFileURL_rawFile_returnsFileSuccessfully() throws {
@@ -237,7 +239,7 @@ extension IONFILEFileManagerTests {
         let returnedURL = try sut.getFileURL(atPath: filePath, withSearchPath: .raw)
 
         // Then
-        XCTAssertEqual(filePath, returnedURL.path())
+        XCTAssertEqual(filePath + "/", returnedURL.path())
     }
 
     func test_getFileURL_rawFile_fromInvalidPath_returnsError() {
@@ -250,6 +252,30 @@ extension IONFILEFileManagerTests {
             // Then
             XCTAssertEqual($0 as? IONFILEFileManagerError, .cantCreateURL(forPath: emptyFilePath))
         }
+    }
+    
+    func test_getFileURL_withFileScheme_returnsFileSuccessfully() throws {
+        // Given
+        createFileManager()
+        let filePath = "file://test/directory"
+
+        // When
+        let returnedURL = try sut.getFileURL(atPath: filePath, withSearchPath: .raw)
+
+        // Then
+        XCTAssertEqual(filePath + "/", returnedURL.absoluteString)
+    }
+    
+    func test_getFileURL_withFileSchemeTripleSlash_returnsFileSuccessfully() throws {
+        // Given
+        createFileManager()
+        let filePath = "file:///test/directory"
+
+        // When
+        let returnedURL = try sut.getFileURL(atPath: filePath, withSearchPath: .raw)
+
+        // Then
+        XCTAssertEqual(filePath + "/", returnedURL.absoluteString)
     }
 }
 


### PR DESCRIPTION
## Description

Proper fix on Android, that adds a missing trailing slash '/' in directories, to [drop this PR](https://github.com/ionic-team/cordova-outsystems-file/pull/10).

Note that with this change, it increases the odds of users adding an unnecessary extra trailing slash, which could break iOS apps; that's why we added a check in this PR to check for duplicates.
I will be opening PRs for file-viewer and file-transfer iOS native library to protect against such scenario as well.

## Context

The goal here is to have the same behavior as the existing Cordova file plugin, while also not breaking the existing Capacitor filesystem plugin.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Tests

Update tests to make sure trailing slash is added, while also making sure duplicated slashes are removed when appropriate.

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
