### PR TITLE
fix: raw file paths without a scheme couldn't be accessed

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   sonarcloud:
     name: Unit-Tests
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/IONFilesystemLib/IONFILEManager.swift
+++ b/IONFilesystemLib/IONFILEManager.swift
@@ -257,8 +257,18 @@ private extension IONFILEManager {
     }
 
     func resolveRawURL(from path: String) throws -> URL {
-        guard let rawURL = URL(string: path) else {
+        guard !path.isEmpty else {
             throw IONFILEFileManagerError.cantCreateURL(forPath: path)
+        }
+
+        // A scheme-less string (e.g. a bare "/var/.../file.txt" path) parses successfully via
+        // `URL(string:)` but isn't a file URL, so reads against it fail. Only trust the parsed
+        // URL when it carries a scheme (e.g. "file://..."); otherwise treat it as a literal path.
+        let rawURL: URL
+        if let parsedURL = URL(string: path), parsedURL.scheme != nil {
+            rawURL = parsedURL
+        } else {
+            rawURL = URL(fileURLWithPath: path)
         }
         return fixPathComponentsIfNeeded(rawURL)
     }

--- a/IONFilesystemLibTests/IONFILEFileManagerTests.swift
+++ b/IONFilesystemLibTests/IONFILEFileManagerTests.swift
@@ -351,8 +351,9 @@ extension IONFILEFileManagerTests {
 
         // Then
         XCTAssertEqual(filePath + "/", returnedURL.path())
+        XCTAssertTrue(returnedURL.isFileURL)
     }
-    
+
     func test_getFileURL_doesNotExist_returnsFileSuccessfully() throws {
         // Given
         createFileManager(fileExists: false)
@@ -363,6 +364,40 @@ extension IONFILEFileManagerTests {
 
         // Then
         XCTAssertEqual(filePath + "/", returnedURL.path())
+        XCTAssertTrue(returnedURL.isFileURL)
+    }
+
+    func test_getFileURL_rawFile_fromBarePath_isResolvedAsFileURL() throws {
+        // Given
+        createFileManager(shouldBeDirectory: false)
+        let filePath = "/test/directory/random_doc.pdf"
+
+        // When
+        let returnedURL = try sut.getFileURL(atPath: filePath, withSearchPath: .raw)
+
+        // Then
+        XCTAssertTrue(returnedURL.isFileURL)
+        XCTAssertEqual(returnedURL.scheme, "file")
+        XCTAssertEqual(returnedURL.absoluteString, "file://" + filePath)
+    }
+
+    func test_getFileURL_rawFile_fromBarePath_canActuallyBeRead() throws {
+        // Given: a bare path (no "file://" scheme), as returned by e.g. the contacts plugin
+        // when writing a contact photo to the temporary directory on iOS.
+        createFileManager(shouldBeDirectory: false)
+        let configurationFileURL = try XCTUnwrap(fetchConfigurationFile())
+        let barePath = configurationFileURL.path
+
+        // When
+        let resolvedURL = try sut.getFileURL(atPath: barePath, withSearchPath: .raw)
+        let result = try sut.readEntireFile(atURL: resolvedURL, withEncoding: .string(encoding: .utf8))
+
+        // Then
+        guard case .string(_, let content) = result else {
+            XCTFail("Wrong result type")
+            return
+        }
+        XCTAssertEqual(content, Configuration.fileContent)
     }
 
     func test_getFileURL_rawFile_fromInvalidPath_returnsError() {
@@ -410,7 +445,7 @@ extension IONFILEFileManagerTests {
         let returnedURL = try sut.getFileURL(atPath: filePath, withSearchPath: .raw)
 
         // Then
-        XCTAssertEqual(filePath, returnedURL.absoluteString)
+        XCTAssertEqual("file://" + filePath, returnedURL.absoluteString)
     }
 }
 


### PR DESCRIPTION
## Description

> ⚠️ 🤖 AI-assisted development with Claude Code, with manual review and tests done by me

Fixes a bug where passing raw file paths (not using a specific `Directory` like `.library`) without a scheme (e.g. no `file://`) was causing them to be incorrectly interpreted as a scheme-less URI (which iOS's file APIs can't actually read from or write to), and fail to be accessed. The fix involves checking if the received input actually has a valid scheme, and if not interpret it as a plain file path and convert to a URI.

## Change Type
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [ ] Other (CI, chores, etc.)

## Rationale / Problems Fixed

Internal JIRA Ref: https://outsystemsrd.atlassian.net/browse/RMET-3892

Testing an app with Contacts and File Plugin. The contact's photo, when available, was coming without a `file://` scheme, which was causing the File Plugin to not access it correctly.

## Tests or Reproductions

Refer to updated unit tests that pass after doing the fix (if you remove the fix they won't pass).

If you want to test on an actual mobile app -> You may use the current "Contacts Sample App" to reproduce the current issue.

To test the fix, you'll need to build [this app from source](https://drive.google.com/file/d/1VNj1cs2yWCrzho_x0F7GqVuuhqMtw93h/view?usp=sharing), which hardcodes an xcframework with this fix (just unzip, open in Xcode and build and run): 

## Screenshots / Media

Before: Check video on RMET-3892

After:  https://github.com/user-attachments/assets/184b793b-4923-4085-af5b-0e7e2c6f5c31
